### PR TITLE
Restore section tags on add-elastic-pool-to-failover-group script

### DIFF
--- a/azure-sql/database/failover-groups/add-elastic-pool-to-failover-group-az-ps.ps1
+++ b/azure-sql/database/failover-groups/add-elastic-pool-to-failover-group-az-ps.ps1
@@ -1,11 +1,16 @@
+﻿
 # <FullScript>
+# Add an elastic pool in Azure SQL Database to a failover group
+
+# <SetVariables>
+
 # Set variables for your server and database
 $subscriptionId = '<Subscription-ID>'
 $randomIdentifier = $(Get-Random)
 $resourceGroupName = "myResourceGroup-$randomIdentifier"
 $location = "East US"
-$adminLogin = "<admin>"
-$password = "<password>"
+$adminLogin = "azureuser"
+$password = "PWD27!"+(New-Guid).Guid
 $serverName = "mysqlserver-$randomIdentifier"
 $poolName = "myElasticPool"
 $databaseName = "mySampleDatabase"
@@ -13,199 +18,190 @@ $drLocation = "West US"
 $drServerName = "mysqlsecondary-$randomIdentifier"
 $failoverGroupName = "failovergrouptutorial-$randomIdentifier"
 
-# The IP address range that you want to allow to access your server
-# Leaving at 0.0.0.0 will prevent outside-of-Azure connections
+
+# The ip address range that you want to allow to access your server 
+# Leaving at 0.0.0.0 will prevent outside-of-azure connections
 $startIp = "0.0.0.0"
 $endIp = "0.0.0.0"
 
 # Show randomized variables
-Write-Host "Resource group name is" $resourceGroupName
-Write-Host "Password is" $password
-Write-Host "Server name is" $serverName
-Write-Host "DR Server name is" $drServerName
-Write-Host "Failover group name is" $failoverGroupName
+Write-host "Resource group name is" $resourceGroupName 
+Write-host "Password is" $password  
+Write-host "Server name is" $serverName 
+Write-host "DR Server name is" $drServerName 
+Write-host "Failover group name is" $failoverGroupName
+
+# </SetVariables>
+
+# <CreateResourceGroup>
 
 # Set subscription ID
-Set-AzContext -SubscriptionId $subscriptionId
+Set-AzContext -SubscriptionId $subscriptionId 
 
 # Create a resource group
-Write-Host "Creating resource group..."
-$resourceGroupParams = @{
-   Name     = $resourceGroupName
-   Location = $location
-   Tag      = @{Owner = "SQLDB-Samples" }
-}
-$resourceGroup = New-AzResourceGroup @resourceGroupParams
+Write-host "Creating resource group..."
+$resourceGroup = New-AzResourceGroup -Name $resourceGroupName -Location $location -Tag @{Owner="SQLDB-Samples"}
 $resourceGroup
 
-# Build the SQL administrator credential reused for both servers
-$adminCredential = New-Object -TypeName System.Management.Automation.PSCredential `
-   -ArgumentList $adminLogin, (ConvertTo-SecureString -String $password -AsPlainText -Force)
+# </CreateResourceGroup>
+
+# <CreatePrimaryPool>
 
 # Create a server with a system-wide unique server name
-Write-Host "Creating primary logical server..."
-$primaryServerParams = @{
-   ResourceGroupName           = $resourceGroupName
-   ServerName                  = $serverName
-   Location                    = $location
-   SqlAdministratorCredentials = $adminCredential
-}
-New-AzSqlServer @primaryServerParams
-Write-Host "Primary logical server = " $serverName
+Write-host "Creating primary logical server..."
+New-AzSqlServer -ResourceGroupName $resourceGroupName `
+   -ServerName $serverName `
+   -Location $location `
+   -SqlAdministratorCredentials $(New-Object -TypeName System.Management.Automation.PSCredential `
+   -ArgumentList $adminLogin, $(ConvertTo-SecureString -String $password -AsPlainText -Force))
+Write-host "Primary logical server = " $serverName
 
 # Create a server firewall rule that allows access from the specified IP range
-Write-Host "Configuring firewall for primary logical server..."
-$primaryFirewallParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   FirewallRuleName  = "AllowedIPs"
-   StartIpAddress    = $startIp
-   EndIpAddress      = $endIp
-}
-New-AzSqlServerFirewallRule @primaryFirewallParams
-Write-Host "Firewall configured"
+Write-host "Configuring firewall for primary logical server..."
+New-AzSqlServerFirewallRule -ResourceGroupName $resourceGroupName `
+   -ServerName $serverName `
+   -FirewallRuleName "AllowedIPs" -StartIpAddress $startIp -EndIpAddress $endIp
+Write-host "Firewall configured" 
 
 # Create General Purpose Gen5 database with 2 vCore
-Write-Host "Creating a gen5 2 vCore database..."
-$databaseParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   DatabaseName      = $databaseName
-   Edition           = "GeneralPurpose"
-   VCore             = 2
-   ComputeGeneration = "Gen5"
-   MinimumCapacity   = 1
-   SampleName        = "AdventureWorksLT"
-}
-$database = New-AzSqlDatabase @databaseParams
+Write-host "Creating a gen5 2 vCore database..."
+$database = New-AzSqlDatabase  -ResourceGroupName $resourceGroupName `
+   -ServerName $serverName `
+   -DatabaseName $databaseName `
+   -Edition "GeneralPurpose" `
+   -VCore 2 `
+   -ComputeGeneration Gen5 `
+   -MinimumCapacity 1 `
+   -SampleName "AdventureWorksLT"
 $database
 
 # Create primary Gen5 elastic 2 vCore pool
-Write-Host "Creating elastic pool..."
-$primaryPoolParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   ElasticPoolName   = $poolName
-   Edition           = "GeneralPurpose"
-   VCore             = 2
-   ComputeGeneration = "Gen5"
-}
-$elasticPool = New-AzSqlElasticPool @primaryPoolParams
+Write-host "Creating elastic pool..."
+$elasticPool = New-AzSqlElasticPool -ResourceGroupName $resourceGroupName `
+    -ServerName $serverName `
+    -ElasticPoolName $poolName `
+    -Edition "GeneralPurpose" `
+    -vCore 2 `
+    -ComputeGeneration Gen5
 $elasticPool
 
-# Add single database into elastic pool
-Write-Host "Creating elastic pool..."
-$addDatabaseParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   DatabaseName      = $databaseName
-   ElasticPoolName   = $poolName
-}
-$addDatabase = Set-AzSqlDatabase @addDatabaseParams
+# Add single db into elastic pool
+Write-host "Creating elastic pool..."
+$addDatabase = Set-AzSqlDatabase -ResourceGroupName $resourceGroupName `
+    -ServerName $serverName `
+    -DatabaseName $databaseName `
+    -ElasticPoolName $poolName
 $addDatabase
 
+# </CreatePrimaryPool>
+
+# <CreateSecondaryPool>
+
 # Create a secondary server in the failover region
-Write-Host "Creating a secondary logical server in the failover region..."
-$secondaryServerParams = @{
-   ResourceGroupName           = $resourceGroupName
-   ServerName                  = $drServerName
-   Location                    = $drLocation
-   SqlAdministratorCredentials = $adminCredential
-}
-New-AzSqlServer @secondaryServerParams
-Write-Host "Secondary logical server =" $drServerName
+Write-host "Creating a secondary logical server in the failover region..."
+New-AzSqlServer -ResourceGroupName $resourceGroupName `
+   -ServerName $drServerName `
+   -Location $drLocation `
+   -SqlAdministratorCredentials $(New-Object -TypeName System.Management.Automation.PSCredential `
+      -ArgumentList $adminlogin, $(ConvertTo-SecureString -String $password -AsPlainText -Force))
+Write-host "Secondary logical server =" $drServerName
 
 # Create a server firewall rule that allows access from the specified IP range
-Write-Host "Configuring firewall for secondary logical server..."
-$secondaryFirewallParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $drServerName
-   FirewallRuleName  = "AllowedIPs"
-   StartIpAddress    = $startIp
-   EndIpAddress      = $endIp
-}
-New-AzSqlServerFirewallRule @secondaryFirewallParams
-Write-Host "Firewall configured"
+Write-host "Configuring firewall for secondary logical server..."
+New-AzSqlServerFirewallRule -ResourceGroupName $resourceGroupName `
+   -ServerName $drServerName `
+   -FirewallRuleName "AllowedIPs" -StartIpAddress $startIp -EndIpAddress $endIp
+Write-host "Firewall configured" 
 
 # Create secondary Gen5 elastic 2 vCore pool
-Write-Host "Creating secondary elastic pool..."
-$secondaryPoolParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $drServerName
-   ElasticPoolName   = $poolName
-   Edition           = "GeneralPurpose"
-   VCore             = 2
-   ComputeGeneration = "Gen5"
-}
-$elasticPool = New-AzSqlElasticPool @secondaryPoolParams
+Write-host "Creating secondary elastic pool..."
+$elasticPool = New-AzSqlElasticPool -ResourceGroupName $resourceGroupName `
+    -ServerName $drServerName `
+    -ElasticPoolName $poolName `
+    -Edition "GeneralPurpose" `
+    -vCore 2 `
+    -ComputeGeneration Gen5
 $elasticPool
 
+# <CreateSecondaryPool>
+
+# <CreateFailoverGroup>
+
 # Create a failover group between the servers
-Write-Host "Creating failover group..."
-$failoverGroupParams = @{
-   ResourceGroupName            = $resourceGroupName
-   ServerName                   = $serverName
-   PartnerServerName            = $drServerName
-   FailoverGroupName            = $failoverGroupName
-   FailoverPolicy               = "Automatic"
-   GracePeriodWithDataLossHours = 2
-}
-New-AzSqlDatabaseFailoverGroup @failoverGroupParams
-Write-Host "Failover group created successfully."
+Write-host "Creating failover group..." 
+New-AzSqlDatabaseFailoverGroup `
+  –ResourceGroupName $resourceGroupName `
+   -ServerName $serverName `
+   -PartnerServerName $drServerName  `
+   –FailoverGroupName $failoverGroupName `
+   –FailoverPolicy Manual
+Write-host "Failover group created successfully." 
+
+# </CreateFailoverGroup>
+
+# <AddPooltoFailoverGroup>
 
 # Add elastic pool to the failover group
-Write-Host "Enumerating databases in elastic pool...."
-$getFailoverGroupParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   FailoverGroupName = $failoverGroupName
-}
-$failoverGroup = Get-AzSqlDatabaseFailoverGroup @getFailoverGroupParams
-$poolDatabaseParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   ElasticPoolName   = $poolName
-}
-$databases = Get-AzSqlElasticPoolDatabase @poolDatabaseParams
-Write-Host "Adding databases to failover group..."
-$failoverGroup = $failoverGroup | Add-AzSqlDatabaseToFailoverGroup -Database $databases
+Write-host "Enumerating databases in elastic pool...." 
+$FailoverGroup = Get-AzSqlDatabaseFailoverGroup `
+                 -ResourceGroupName $resourceGroupName `
+                 -ServerName $serverName `
+                 -FailoverGroupName $failoverGroupName
+$databases = Get-AzSqlElasticPoolDatabase `
+               -ResourceGroupName $resourceGroupName `
+               -ServerName $serverName `
+               -ElasticPoolName $poolName
+Write-host "Adding databases to failover group..." 
+$failoverGroup = $failoverGroup | Add-AzSqlDatabaseToFailoverGroup `
+                                  -Database $databases 
 $failoverGroup
 
-# Check role of secondary replica
-Write-Host "Confirming the secondary server is secondary...."
-$secondaryRoleParams = @{
-   FailoverGroupName = $failoverGroupName
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $drServerName
-}
-(Get-AzSqlDatabaseFailoverGroup @secondaryRoleParams).ReplicationRole
+# </AddPooltoFailoverGroup>
 
+# <CheckRole>
+
+# Check role of secondary replica
+Write-host "Confirming the secondary server is secondary...." 
+(Get-AzSqlDatabaseFailoverGroup `
+   -FailoverGroupName $failoverGroupName `
+   -ResourceGroupName $resourceGroupName `
+   -ServerName $drServerName).ReplicationRole
+
+# </CheckRole>
+
+# <Failover>
 # Failover to secondary server
-Write-Host "Failing over failover group to the secondary..."
-$switchToSecondaryParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $drServerName
-   FailoverGroupName = $failoverGroupName
-}
-Switch-AzSqlDatabaseFailoverGroup @switchToSecondaryParams
-Write-Host "Failover group failed over to" $drServerName
+Write-host "Failing over failover group to the secondary..." 
+Switch-AzSqlDatabaseFailoverGroup `
+   -ResourceGroupName $resourceGroupName `
+   -ServerName $drServerName `
+   -FailoverGroupName $failoverGroupName
+Write-host "Failover group failed over to" $drServerName 
 
 # Check role of secondary replica
-Write-Host "Confirming the secondary server is now primary"
-(Get-AzSqlDatabaseFailoverGroup @secondaryRoleParams).ReplicationRole
+Write-host "Confirming the secondary server is now primary" 
+(Get-AzSqlDatabaseFailoverGroup `
+   -FailoverGroupName $failoverGroupName `
+   -ResourceGroupName $resourceGroupName `
+   -ServerName $drServerName).ReplicationRole
+
+# </Failover>
+
+# <FailBack>
 
 # Revert failover to primary server
-Write-Host "Failing over failover group to the primary...."
-$switchToPrimaryParams = @{
-   ResourceGroupName = $resourceGroupName
-   ServerName        = $serverName
-   FailoverGroupName = $failoverGroupName
-}
-Switch-AzSqlDatabaseFailoverGroup @switchToPrimaryParams
-Write-Host "Failover group failed over to" $serverName
+Write-host "Failing over failover group to the primary...." 
+Switch-AzSqlDatabaseFailoverGroup `
+   -ResourceGroupName $resourceGroupName `
+   -ServerName $serverName `
+   -FailoverGroupName $failoverGroupName
+Write-host "Failover group failed over to" $serverName 
+
+# </FailBack>
 
 # Clean up resources by removing the resource group
-# Write-Host "Removing resource group..."
+# Write-host "Removing resource group..."
 # Remove-AzResourceGroup -ResourceGroupName $resourceGroupName
-# Write-Host "Resource group removed =" $resourceGroupName
+# Write-host "Resource group removed =" $resourceGroupName
+
 # </FullScript>


### PR DESCRIPTION
## Summary

Restores the granular snippet section tags on `azure-sql/database/failover-groups/add-elastic-pool-to-failover-group-az-ps.ps1`.

PR #58 replaced this script with a refreshed version wrapped in only `# <FullScript>`, which inadvertently dropped the section tags (`SetVariables`, `CreateResourceGroup`, `CreateFailoverGroup`, `AddPooltoFailoverGroup`, `CheckRole`, `Failover`, `FailBack`, etc.).

The Microsoft Learn article `azure-sql/database/failover-group-configure-sql-db.md` references these section IDs via `:::code ... id="...":::`, so the build now reports `invalid-code` warnings ("code snippet was not rendered"). This restores the original section-tagged version so those references resolve again.

## Change

- `azure-sql/database/failover-groups/add-elastic-pool-to-failover-group-az-ps.ps1` — restored section tags (including `# <FullScript>`) from the pre-#58 version.

## Validation

- All section IDs referenced by `failover-group-configure-sql-db.md` (`CreateFailoverGroup`, `AddPooltoFailoverGroup`, `CheckRole`, `Failover`, `FailBack`) now have matching open/close tags.
- `# <FullScript>` is preserved for the `add-elastic-pool-to-failover-group-powershell.md` article reference.